### PR TITLE
Made it so the Connect code box will put you at the start of the box

### DIFF
--- a/AmongUsCapture/UserForm.Designer.cs
+++ b/AmongUsCapture/UserForm.Designer.cs
@@ -113,14 +113,16 @@
             // ConnectCodeBox
             // 
             this.ConnectCodeBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.ConnectCodeBox.Font = new System.Drawing.Font("Cascadia Code", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.ConnectCodeBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.ConnectCodeBox.Location = new System.Drawing.Point(9, 22);
             this.ConnectCodeBox.Mask = ">AAAAAA";
             this.ConnectCodeBox.Name = "ConnectCodeBox";
-            this.ConnectCodeBox.Size = new System.Drawing.Size(100, 23);
+            this.ConnectCodeBox.Size = new System.Drawing.Size(100, 22);
             this.ConnectCodeBox.TabIndex = 1;
             this.ConnectCodeBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.ConnectCodeBox.Click += new System.EventHandler(this.ConnectCodeBox_Click);
             this.ConnectCodeBox.TextChanged += new System.EventHandler(this.ConnectCodeBox_TextChanged);
+            this.ConnectCodeBox.Enter += new System.EventHandler(this.ConnectCodeBox_Enter);
             // 
             // UrlGB
             // 

--- a/AmongUsCapture/UserForm.cs
+++ b/AmongUsCapture/UserForm.cs
@@ -28,12 +28,12 @@ namespace AmongUsCapture
 
             // Submit on Enter
             this.AcceptButton = ConnectButton;
-        
-            if(DarkTheme())
+
+            if (DarkTheme())
             {
                 EnableDarkTheme();
             }
-            
+
         }
         private bool DarkTheme()
         {
@@ -82,13 +82,31 @@ namespace AmongUsCapture
 
             ConnectButton.BackColor = BluePurpleAccent;
             ConnectButton.ForeColor = White;
-            
+
 
             BackColor = DarkGrey;
             ForeColor = White;
 
         }
 
+        private void ConnectCodeBox_Enter(object sender, EventArgs e)
+        {
+            this.BeginInvoke((MethodInvoker)delegate ()
+            {
+                ConnectCodeBox.Select(0, 0);
+            });
+        }
+        private void ConnectCodeBox_Click(object sender, EventArgs e)
+        {
+            if (ConnectCodeBox.Enabled)
+            {
+                this.BeginInvoke((MethodInvoker)delegate ()
+                {
+                    ConnectCodeBox.Select(0, 0);
+                });
+            }
+
+        }
 
         private void UserForm_PlayerChanged(object sender, PlayerChangedEventArgs e)
         {
@@ -111,7 +129,7 @@ namespace AmongUsCapture
 
         private void SubmitButton_Click(object sender, EventArgs e)
         {
-        
+
             ConnectCodeBox.Enabled = false;
             ConnectButton.Enabled = false;
             URLTextBox.Enabled = false;
@@ -130,7 +148,8 @@ namespace AmongUsCapture
             try
             {
                 await clientSocket.Connect(url);
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 MessageBox.Show(e.Message, "Error", MessageBoxButtons.OK);
                 ConnectCodeBox.Enabled = true;
@@ -151,7 +170,7 @@ namespace AmongUsCapture
         {
             ConnectButton.Enabled = (ConnectCodeBox.Enabled && ConnectCodeBox.Text.Length == 6 && !ConnectCodeBox.Text.Contains(" "));
         }
-        
+
         public void WriteLineToConsole(String line)
         {
             if (!(ConsoleTextBox is null))


### PR DESCRIPTION
This makes it so when you click into the Connect code box it will put you at the beginning, not at the middle or wherever you clicked at.